### PR TITLE
add rbac permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,9 +5,30 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - services
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
   - kubepurge.xyz
   resources:
   - purgepolicies
+  - purgestatuses
   verbs:
   - create
   - delete

--- a/internal/controller/purgepolicy_controller.go
+++ b/internal/controller/purgepolicy_controller.go
@@ -38,6 +38,13 @@ type PurgePolicyReconciler struct {
 // +kubebuilder:rbac:groups=kubepurge.xyz,resources=purgepolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubepurge.xyz,resources=purgepolicies/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kubepurge.xyz,resources=purgepolicies/finalizers,verbs=update
+// +kubebuilder:rbac:groups=kubepurge.xyz,resources=purgestatuses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;delete
+// +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;delete
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.0/pkg/reconcile


### PR DESCRIPTION
## Summary
- Add RBAC permissions for resource deletion operations
- Include permissions for pods, deployments, services, configmaps, secrets
- Add PurgeStatus resource management permissions
- Generate updated ClusterRole manifest